### PR TITLE
`didRender` helper

### DIFF
--- a/src/did-render.ts
+++ b/src/did-render.ts
@@ -1,0 +1,11 @@
+async function didRender(app: any): Promise<void> {
+  return new Promise<void>(resolve => {
+    let watcher = setInterval(function() {
+      if (app['_rendering']) return;
+      clearInterval(watcher);
+      resolve();
+    }, 10);
+  });
+};
+
+export default didRender;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './app-builder';
 export * from './compiler';
 export { default as defaultResolverConfiguration } from './default-resolver-configuration';
+export { default as didRender } from './did-render';


### PR DESCRIPTION
Dependent upon https://github.com/glimmerjs/glimmer-application/pull/70.

Works in a similar way to `wait`. I didn't call it wait though because we're specifically waiting on rendering. And also `await wait(app)` is weird to read. Or maybe not?

Example usage:

```typescript
test('renders a component', async function(assert) {
  // ...

  app.renderComponent('hello-world', containerElement);

  await didRender(app);

  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
});
```